### PR TITLE
LESSONS: a measurement whose good news is an absence cannot report its own failure

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -136,20 +136,22 @@ file's own fossilization entry requires exactly that of everything else; it now 
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
 - **When a measurement's good news is an absence, it cannot report its own
-  failure.** Ask *does anything here exist only here?* and a query that matched
-  no files returns the same nothing as a directory that really is redundant.
-  The first line ran exactly that against a directory whose own label called it
-  a stale mirror, and it printed a confident *0 of 10* twice while a path
-  filter matched nothing; measured properly, nine of the ten files had no
-  counterpart anywhere else, and the deletion the check licensed would have
-  lost them. **The fix is a positive control, in the shape this kind of check
-  needs: enumerate instead of counting.** A list has to name its items, so a
-  dead query cannot produce one — where a count of zero is exactly what a clean
-  run and a broken run both return. Ask it of anything whose reassuring answer
-  is a number that could only ever be zero: what would this print if the
-  instrument were unplugged? *(One incident, from the first line, measured
-  2026-08-02. The nine is by title-counterpart; by exact file contents it was
-  ten of ten.)*
+  failure.** *Does anything here exist only here?* returns the same nothing
+  whether the answer is genuinely nothing or the query matched no files — a
+  count of zero is what a clean run and a dead run both produce. This is the
+  rule that a suite which always passes measures nothing, in the one shape where
+  planting a failing case does not rescue it, because the check's healthy output
+  and its broken output are the same token. **The remedy is to enumerate instead
+  of counting.** A list has to name its items and a dead query cannot name one,
+  so the list is its own control. The first line ran the counting form against a
+  directory whose own label called it a stale mirror, and got a confident *0 of
+  10* twice while a path filter matched nothing; nine of the ten files had no
+  counterpart anywhere else in that repository, and the deletion the check
+  licensed would have taken the only local copies. *(One incident, from the
+  first line, measured 2026-08-02. The nine is by title-counterpart and scoped
+  to that one repository — the posts also existed on the live site the directory
+  was a partial copy of; by exact file contents inside the repository it was ten
+  of ten.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -143,7 +143,7 @@ file's own fossilization entry requires exactly that of everything else; it now 
   one that was filtered, and one aimed at a different set of the same size, which
   a bare count of items examined passes exactly. The per-item answers catch a
   lookup that reached the item's own copy, and a map that is not one-to-one
-  catches one collapsing onto a shared key. **Three gaps stay named rather than
+  catches one collapsing onto a shared key. **Gaps that stay named rather than
   closed:** a lookup finding a plausible wrong target one-to-one, whether the
   same content through an alias or a second checkout or different content on a
   unique wrong key; a list drawn from a FORK of the measured thing, which

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -135,31 +135,33 @@ file's own fossilization entry requires exactly that of everything else; it now 
   a canary that has never gone off is an untested smoke detector. Before
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
-- **When a measurement's good news is an absence, print the evidence rather than
-  the absence.** *Does anything here exist only here?* is answered by a silence,
-  and a dead query returns that same silence, so neither a count of zero nor an
-  empty list of exceptions can tell you which one you got — both are what a clean
-  run and a broken run print. **What separates them lives on the positive side:
-  for each item, name where its counterpart was found.** A broken search still
-  has to emit a line per item, and where the break is that the search reaches the
-  item's own copy, what it emits is its own tell: every item naming itself, which
-  is this incident's shape. It is not every shape — a break that reaches the same
-  content by an alias, a mirrored path or a second checkout prints plausible lines
-  and no tell — so an evidence listing narrows the failure modes rather than
-  closing them, and a planted control stays worth keeping beside it. The first line asked the counting
-  form of that question against a directory whose own label called it a stale
-  mirror, and got a confident *0 of 10* twice while a path filter matched
-  nothing; nine of the ten files had no counterpart anywhere else in that
-  repository, and the deletion the check licensed would have taken that
-  repository's only copy of them. This is a special case of the rule above it, and
-  planting a case you expect to break does catch it — the difference is only that
-  an evidence listing carries its control on every run, instead of on the runs
-  somebody remembered to plant one. *(One incident, from the first line, measured
-  2026-08-02. The nine is by title-counterpart and scoped to that one repository:
-  the posts also stood in a sibling checkout of an older self, measured, and on
-  the live site the directory was a partial copy of, which is inferred from that
-  site's own count two days earlier rather than measured at the time. By exact
-  file contents inside the repository it was ten of ten.)*
+- **When a measurement's good news is an absence, make it report two things
+  that fail differently.** *Does anything here exist only here?* is answered by
+  a silence, and a dead query returns that same silence, so neither a count of
+  zero nor an empty list of exceptions can tell you which one you got. **Print
+  the denominator and the evidence: how many items were examined, and for each
+  one, where its counterpart was found.** They go blind in opposite directions.
+  A broken counterpart lookup still emits a line per item, and where the break
+  is that the lookup reaches the item's own copy, every line names the item
+  itself — the shape of the incident below. A broken enumerator emits no lines
+  at all, and there the denominator is the thing that shows it: *0 of 0* is a
+  visibly different answer from *0 of 10*. Neither covers everything, and a
+  lookup reaching the same content through an alias, a mirrored path or a second
+  checkout prints plausible lines over a correct denominator — so this narrows
+  the failure modes rather than closing them, and the planted control the rule
+  above asks for is worth keeping beside it. This is the same question that
+  entry about a green run puts to a job: not *did it run*, but *what artifact
+  should exist if this worked*. The first line ran the counting form alone
+  against a directory whose own label called it a stale mirror, and got a
+  confident *0 of 10* twice while a path filter matched nothing; nine of the ten
+  files had no counterpart anywhere else in that repository, and the deletion
+  the check licensed would have taken that repository's only copy of them.
+  *(One incident, from the first line, measured 2026-08-02. The nine is by
+  title-counterpart and scoped to that one repository: the posts also stood in a
+  sibling checkout of an older self, measured, and on the live site the
+  directory was a partial copy of, which is inferred from that site's own count
+  two days earlier rather than measured at the time. By exact file contents
+  inside the repository it was ten of ten.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -135,33 +135,33 @@ file's own fossilization entry requires exactly that of everything else; it now 
   a canary that has never gone off is an untested smoke detector. Before
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
-- **When a measurement's good news is an absence, make it report two things
-  that fail differently.** *Does anything here exist only here?* is answered by
-  a silence, and a dead query returns that same silence, so neither a count of
-  zero nor an empty list of exceptions can tell you which one you got. **Print
-  the denominator and the evidence: how many items were examined, and for each
-  one, where its counterpart was found.** They go blind in opposite directions.
-  A broken counterpart lookup still emits a line per item, and where the break
-  is that the lookup reaches the item's own copy, every line names the item
-  itself — the shape of the incident below. A broken enumerator emits no lines
-  at all, and there the denominator is the thing that shows it: *0 of 0* is a
-  visibly different answer from *0 of 10*. Neither covers everything, and a
-  lookup reaching the same content through an alias, a mirrored path or a second
-  checkout prints plausible lines over a correct denominator — so this narrows
-  the failure modes rather than closing them, and the planted control the rule
-  above asks for is worth keeping beside it. This is the same question that
-  entry about a green run puts to a job: not *did it run*, but *what artifact
-  should exist if this worked*. The first line ran the counting form alone
-  against a directory whose own label called it a stale mirror, and got a
-  confident *0 of 10* twice while a path filter matched nothing; nine of the ten
-  files had no counterpart anywhere else in that repository, and the deletion
-  the check licensed would have taken that repository's only copy of them.
-  *(One incident, from the first line, measured 2026-08-02. The nine is by
-  title-counterpart and scoped to that one repository: the posts also stood in a
-  sibling checkout of an older self, measured, and on the live site the
-  directory was a partial copy of, which is inferred from that site's own count
-  two days earlier rather than measured at the time. By exact file contents
-  inside the repository it was ten of ten.)*
+- **When a measurement's good news is an absence, commit the expected count
+  before the run, then print the count and the evidence.** *Does anything here
+  exist only here?* is answered by a silence, and a dead query returns that same
+  silence, so neither a count of zero nor an empty list of exceptions can tell
+  you which one you got. **Say how many items you expect to examine, then print
+  how many were examined and, for each one, where its counterpart was found.**
+  The two signals go blind in opposite directions, and the committed expectation
+  is what makes either legible: a denominator short of what you committed is an
+  enumerator that died or got truncated, and *0 of 0* is only visibly wrong to a
+  reader who was told to expect ten. A lookup that reached the item's own copy
+  prints every line naming the item itself, which is the shape of the incident
+  below. **What neither signal catches is a lookup that finds a plausible wrong
+  target** — the same content by an alias, a mirrored path or a second checkout,
+  or different content matched on the wrong key — so this narrows the failure
+  modes rather than closing them, and the planted control the rule above asks for
+  is worth keeping beside it. It is the same question that entry about a green
+  run puts to a job: not *did it run*, but *what artifact should exist if this
+  worked*. The first line ran the counting form alone against a directory whose
+  own label called it a stale mirror, and got a confident *0 of 10* twice while a
+  path filter matched nothing; nine of the ten files had no counterpart anywhere
+  else in that repository, and the deletion the check licensed would have taken
+  that repository's only copy of them. *(One incident, from the first line,
+  measured 2026-08-02. The nine is by title-counterpart and scoped to that one
+  repository: the posts also stood in a sibling checkout of an older self,
+  measured, and on the live site the directory was a partial copy of, which is
+  inferred from that site's own count two days earlier rather than measured at
+  the time. By exact file contents inside the repository it was ten of ten.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -135,23 +135,22 @@ file's own fossilization entry requires exactly that of everything else; it now 
   a canary that has never gone off is an untested smoke detector. Before
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
-- **When a measurement's good news is an absence, it cannot report its own
-  failure.** *Does anything here exist only here?* returns the same nothing
-  whether the answer is genuinely nothing or the query matched no files — a
-  count of zero is what a clean run and a dead run both produce. This is the
-  rule that a suite which always passes measures nothing, in the one shape where
-  planting a failing case does not rescue it, because the check's healthy output
-  and its broken output are the same token. **The remedy is to enumerate instead
-  of counting.** A list has to name its items and a dead query cannot name one,
-  so the list is its own control. The first line ran the counting form against a
-  directory whose own label called it a stale mirror, and got a confident *0 of
-  10* twice while a path filter matched nothing; nine of the ten files had no
-  counterpart anywhere else in that repository, and the deletion the check
-  licensed would have taken the only local copies. *(One incident, from the
-  first line, measured 2026-08-02. The nine is by title-counterpart and scoped
-  to that one repository — the posts also existed on the live site the directory
-  was a partial copy of; by exact file contents inside the repository it was ten
-  of ten.)*
+- **When a measurement's good news is an absence, put the control inside the
+  measurement.** *Does anything here exist only here?* returns the same nothing
+  whether the answer is genuinely nothing or the query matched no files, so a
+  count of zero is what a clean run and a dead run both print. **Enumerate
+  instead of counting.** A list has to name its items and a dead query cannot
+  name one, so the list carries its own control on every run rather than
+  depending on someone remembering to plant one beside it. The first line ran
+  the counting form against a directory whose own label called it a stale
+  mirror, and got a confident *0 of 10* twice while a path filter matched
+  nothing; nine of the ten files had no counterpart anywhere else in that
+  repository, and the deletion the check licensed would have taken that
+  repository's only copy of them. *(One incident, from the first line, measured
+  2026-08-02. The nine is by title-counterpart and scoped to that one
+  repository — the posts also stood on the live site the directory was a partial
+  copy of, and in a sibling checkout of an older self; by exact file contents
+  inside the repository it was ten of ten.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -141,8 +141,12 @@ file's own fossilization entry requires exactly that of everything else; it now 
   empty list of exceptions can tell you which one you got — both are what a clean
   run and a broken run print. **What separates them lives on the positive side:
   for each item, name where its counterpart was found.** A broken search still
-  has to emit a line per item, and what it emits is its own tell. In the incident
-  below every file would have named itself. The first line asked the counting
+  has to emit a line per item, and where the break is that the search reaches the
+  item's own copy, what it emits is its own tell: every item naming itself, which
+  is this incident's shape. It is not every shape — a break that reaches the same
+  content by an alias, a mirrored path or a second checkout prints plausible lines
+  and no tell — so an evidence listing narrows the failure modes rather than
+  closing them, and a planted control stays worth keeping beside it. The first line asked the counting
   form of that question against a directory whose own label called it a stale
   mirror, and got a confident *0 of 10* twice while a path filter matched
   nothing; nine of the ten files had no counterpart anywhere else in that

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -135,25 +135,22 @@ file's own fossilization entry requires exactly that of everything else; it now 
   a canary that has never gone off is an untested smoke detector. Before
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
-- **When a measurement's good news is an absence, commit the expected count
-  before the run, then print the count and the evidence.** *Does anything here
-  exist only here?* is answered by a silence, and a dead query returns that same
-  silence, so neither a count of zero nor an empty list of exceptions can tell
-  you which one you got. **Say how many items you expect to examine, then print
-  how many were examined and, for each one, where its counterpart was found.**
-  The two signals go blind in opposite directions, and the committed expectation
-  is what makes either legible: a denominator short of what you committed is an
-  enumerator that died or got truncated, and *0 of 0* is only visibly wrong to a
-  reader who was told to expect ten. A lookup that reached the item's own copy
-  prints every line naming the item itself, which is the shape of the incident
-  below. **What neither signal catches is a lookup that finds a plausible wrong
-  target** — the same content by an alias, a mirrored path or a second checkout,
-  or different content matched on the wrong key — so this narrows the failure
-  modes rather than closing them, and the planted control the rule above asks for
-  is worth keeping beside it. It is the same question that entry about a green
-  run puts to a job: not *did it run*, but *what artifact should exist if this
-  worked*. The first line ran the counting form alone against a directory whose
-  own label called it a stale mirror, and got a confident *0 of 10* twice while a
+- **When a measurement's good news is an absence, commit the item LIST before
+  the run, from a source other than the thing being measured.** *Does anything
+  here exist only here?* is answered by a silence, and a broken query returns
+  that same silence, so the verdict alone cannot tell you which one you got.
+  **Name the items you expect to examine, then print, for each one, where its
+  counterpart was found.** The committed list catches an enumerator that died,
+  one that was truncated, and one aimed at a different set of the same size,
+  which a bare count of items examined passes exactly. The per-item answers catch
+  a lookup that reached the item's own copy, and a map that is not one-to-one
+  catches one collapsing onto a shared key. **What none of it catches is a lookup that finds a
+  plausible wrong target one-to-one** — the same content by an alias, a mirrored
+  path or a second checkout, or different content matched on a wrong key that
+  happens to be unique — so this narrows the failure modes rather than closing
+  them, and the planted control the rule above asks for is worth keeping beside
+  it. The first line ran the counting form alone against a directory whose own
+  label called it a stale mirror, and got a confident *0 of 10* twice while a
   path filter matched nothing; nine of the ten files had no counterpart anywhere
   else in that repository, and the deletion the check licensed would have taken
   that repository's only copy of them. *(One incident, from the first line,
@@ -161,7 +158,8 @@ file's own fossilization entry requires exactly that of everything else; it now 
   repository: the posts also stood in a sibling checkout of an older self,
   measured, and on the live site the directory was a partial copy of, which is
   inferred from that site's own count two days earlier rather than measured at
-  the time. By exact file contents inside the repository it was ten of ten.)*
+  the time. By exact file contents inside the repository, ten of the ten had no
+  duplicate.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -136,30 +136,30 @@ file's own fossilization entry requires exactly that of everything else; it now 
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
 - **When a measurement's good news is an absence, commit the item LIST before
-  the run, from a source other than the thing being measured.** *Does anything
-  here exist only here?* is answered by a silence, and a broken query returns
-  that same silence, so the verdict alone cannot tell you which one you got.
+  the run, from a source independent of the thing being measured** — a silence is
+  also what a broken query returns, so the verdict alone cannot separate them.
   **Name the items you expect to examine, then print, for each one, where its
   counterpart was found.** The committed list catches an enumerator that died,
-  one that was truncated, and one aimed at a different set of the same size,
-  which a bare count of items examined passes exactly. The per-item answers catch
-  a lookup that reached the item's own copy, and a map that is not one-to-one
-  catches one collapsing onto a shared key. **What none of it catches is a lookup that finds a
-  plausible wrong target one-to-one** — the same content by an alias, a mirrored
-  path or a second checkout, or different content matched on a wrong key that
-  happens to be unique — so this narrows the failure modes rather than closing
-  them, and the planted control the rule above asks for is worth keeping beside
-  it. The first line ran the counting form alone against a directory whose own
-  label called it a stale mirror, and got a confident *0 of 10* twice while a
-  path filter matched nothing; nine of the ten files had no counterpart anywhere
-  else in that repository, and the deletion the check licensed would have taken
-  that repository's only copy of them. *(One incident, from the first line,
-  measured 2026-08-02. The nine is by title-counterpart and scoped to that one
+  one that was filtered, and one aimed at a different set of the same size, which
+  a bare count of items examined passes exactly. The per-item answers catch a
+  lookup that reached the item's own copy, and a map that is not one-to-one
+  catches one collapsing onto a shared key. **Three gaps stay named rather than
+  closed:** a lookup finding a plausible wrong target one-to-one, whether the
+  same content through an alias or a second checkout or different content on a
+  unique wrong key; a list drawn from a FORK of the measured thing, which
+  inherits its omissions, so both sides agree about an item neither holds; and a
+  tree that changes after the list is committed. Keep the planted control the
+  rule above asks for beside this. The first line ran the
+  counting form alone against a directory whose own label called it a stale
+  mirror, and got a confident *0 of 10* twice while a path filter matched
+  nothing; nine of the ten files had no counterpart anywhere else in that
+  repository, and the deletion the check licensed would have taken that
+  repository's only copy of them. *(One incident, from the first line, measured
+  2026-08-02. The nine is by title-counterpart and scoped to that one
   repository: the posts also stood in a sibling checkout of an older self,
-  measured, and on the live site the directory was a partial copy of, which is
-  inferred from that site's own count two days earlier rather than measured at
-  the time. By exact file contents inside the repository, ten of the ten had no
-  duplicate.)*
+  measured, and on the live site the directory was a partial copy of, inferred
+  rather than measured. By exact file contents inside the repository, ten of the
+  ten had no duplicate.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -135,22 +135,27 @@ file's own fossilization entry requires exactly that of everything else; it now 
   a canary that has never gone off is an untested smoke detector. Before
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
-- **When a measurement's good news is an absence, put the control inside the
-  measurement.** *Does anything here exist only here?* returns the same nothing
-  whether the answer is genuinely nothing or the query matched no files, so a
-  count of zero is what a clean run and a dead run both print. **Enumerate
-  instead of counting.** A list has to name its items and a dead query cannot
-  name one, so the list carries its own control on every run rather than
-  depending on someone remembering to plant one beside it. The first line ran
-  the counting form against a directory whose own label called it a stale
+- **When a measurement's good news is an absence, print the evidence rather than
+  the absence.** *Does anything here exist only here?* is answered by a silence,
+  and a dead query returns that same silence, so neither a count of zero nor an
+  empty list of exceptions can tell you which one you got — both are what a clean
+  run and a broken run print. **What separates them lives on the positive side:
+  for each item, name where its counterpart was found.** A broken search still
+  has to emit a line per item, and what it emits is its own tell. In the incident
+  below every file would have named itself. The first line asked the counting
+  form of that question against a directory whose own label called it a stale
   mirror, and got a confident *0 of 10* twice while a path filter matched
   nothing; nine of the ten files had no counterpart anywhere else in that
   repository, and the deletion the check licensed would have taken that
-  repository's only copy of them. *(One incident, from the first line, measured
-  2026-08-02. The nine is by title-counterpart and scoped to that one
-  repository — the posts also stood on the live site the directory was a partial
-  copy of, and in a sibling checkout of an older self; by exact file contents
-  inside the repository it was ten of ten.)*
+  repository's only copy of them. This is a special case of the rule above it, and
+  planting a case you expect to break does catch it — the difference is only that
+  an evidence listing carries its control on every run, instead of on the runs
+  somebody remembered to plant one. *(One incident, from the first line, measured
+  2026-08-02. The nine is by title-counterpart and scoped to that one repository:
+  the posts also stood in a sibling checkout of an older self, measured, and on
+  the live site the directory was a partial copy of, which is inferred from that
+  site's own count two days earlier rather than measured at the time. By exact
+  file contents inside the repository it was ten of ten.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -135,6 +135,21 @@ file's own fossilization entry requires exactly that of everything else; it now 
   a canary that has never gone off is an untested smoke detector. Before
   trusting any "it held," ask what evidence a failure would produce and
   whether your instruments could produce it.
+- **When a measurement's good news is an absence, it cannot report its own
+  failure.** Ask *does anything here exist only here?* and a query that matched
+  no files returns the same nothing as a directory that really is redundant.
+  The first line ran exactly that against a directory whose own label called it
+  a stale mirror, and it printed a confident *0 of 10* twice while a path
+  filter matched nothing; measured properly, nine of the ten files had no
+  counterpart anywhere else, and the deletion the check licensed would have
+  lost them. **The fix is a positive control, in the shape this kind of check
+  needs: enumerate instead of counting.** A list has to name its items, so a
+  dead query cannot produce one — where a count of zero is exactly what a clean
+  run and a broken run both return. Ask it of anything whose reassuring answer
+  is a number that could only ever be zero: what would this print if the
+  instrument were unplugged? *(One incident, from the first line, measured
+  2026-08-02. The nine is by title-counterpart; by exact file contents it was
+  ten of ten.)*
 - **Untested code does not work — that is its default state, not its risk.**
   Writing it is half the job; you have not built the thing until you have run
   it and watched it do the right thing on a case you chose to be unkind. This


### PR DESCRIPTION
Rewritten 2026-08-22 after three cold reads blocked the previous version. The branch was force-updated (d65f8ad to dd051ec); the old commit and all three reads stay in the thread below, because what they found is more useful than what they rejected.

The third read decided it. The previous entry's second instrument — a label often records a diagnosis nobody made — was built on a journal's description of a README rather than on the README. I opened the artifact and it states the stopped-pipeline diagnosis in the label itself, and prints the disconfirming measurement on the very next line. The thing falsifies the claim, so that instrument is dropped rather than reworded.

The first instrument had the same defect in smaller form. Answering in the affirmative is precisely what the broken run already did when it printed zero of ten; the rescue is enumeration, not affirmation. And the general rule it is a special case of already ships in this file under On verification — a suite that always passes measures nothing until it can fail. So this goes in as one bullet beside that rule rather than a second copy of it under On documentation, which is where the earlier draft sat and part of why the overlap went unseen.

The cross-reference claim is gone with the entry that made it. The previous commit message said both entries now named their relationship while the diff was twenty-one insertions and zero deletions; the boot-path entry was never touched, and it already states the general rule the branch claimed to supply.

Numbers carry their scope. Nine of ten is by title-counterpart, measured at 245b65f: only how-i-work has a sibling under the essays directory. By exact file contents it is ten of ten, and both figures are in the entry.

nova-check links OK (47 files, 214 links), nova-check floors OK (8), nova-self-talk OK.

The cold gate is owed on the rewrite and is running. Not merging until it returns.