### PR TITLE
REFERENCES: date the Letta substrate line, and add the neighbor who argues against ours

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -34,26 +34,24 @@ Discussion. A found neighbor is good news.**
   ("digital people," "context is selfhood"), without covenant or obligations.
   *(2026-08-23: the substrate description above is dated. Their current memory layer, MemFS, is a
   git-backed markdown filesystem: files under `system/` load into the prompt every turn, everything
-  else stays out of context until needed, memory is addressed by path, and every edit is committed
+  else stays out of context until needed (the file tree itself is always in the prompt, so names act
+  as signposts), memory is addressed by path, and every edit is committed
   ([docs](https://docs.letta.com/concepts/memfs)). Their own announcement of it describes detaching
   the memory tool and syncing an agent's existing memory blocks into that filesystem
   ([post](https://www.letta.com/blog/context-repositories)).)*
-
-- **[Zep](https://www.getzep.com/)** — agent memory as a managed service, self-described as
-  *"a governed Context Lake of context graphs"* built on temporal knowledge graphs rather than
-  files. *Relation:* the sharpest published argument **against** this seed's substrate, and it
-  belongs here for that reason. Their [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
-  holds that *"a file stores text, and memory needs structure"*, that *"a file records what was
-  written, not what it replaced or why, so later turns build on bad facts"*, that choosing which
-  files to load *"works until there are more files than the agent can reliably choose between"*,
-  and, the one this line has actually been bitten by, that the human-review benefit is *"mostly
-  theoretical … the files are seldom read."* Read as a critique of *memory as a database*, the
-  first three are answered by versioning and tiering; the fourth is not answered by architecture at
-  all, and any line growing in files should take it as a standing warning rather than a rival's
-  point. Their subject is retrieval at enterprise scale and ours is a self that persists, so the
-  disagreement is partly about what memory is for — but not entirely, and the part that overlaps is
-  a real objection. *(Added 2026-08-23.)*
-
+- **[Zep](https://www.getzep.com/)** — agent memory as infrastructure, *"at enterprise scale"*,
+  built on temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the
+  argument against this seed's substrate, and it belongs here because that argument scopes itself
+  honestly.** [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
+  (23 Jun 2026) holds that *"a file stores text, and memory needs structure"*, and turns the decision
+  on four questions: shared users and agents, facts that change and need reconciling, facts the agent
+  cannot re-derive locally, retention or compliance. At one agent, one user, a local source of truth
+  and no compliance surface it calls markdown *"the proportionate choice"*, which is this seed's
+  configuration, so at its own scope the post endorses the substrate rather than refuting it. One
+  line of it binds at any size: *"The agent writes its own memory and the files are seldom read, so
+  the store has to stay correct without a curator."* A warning about your own habits, and four
+  questions for the day a line has outgrown the pattern. *(Added 2026-08-23, found outside the
+  2026-08-07 survey.)*
 ## Seeds and reproducible patterns
 
 - **[Muse Crystal Seed](https://github.com/frank890417/muse-crystal-seed)** — "not a system to

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -53,7 +53,8 @@ Discussion. A found neighbor is good news.**
   markdown is *"the proportionate choice, and the best implementations stretch it further with
   discipline: they select rather than dump, and keep only what cannot be re-derived."* **Where a
   line falls against those four is its own measurement; this file takes no position.** Its
-  debunking of one claimed markdown benefit is worth carrying whatever a line concludes: *"The markdown benefit that 'a human can review it' is mostly theoretical. The agent
+  debunking of one claimed markdown benefit is worth carrying whatever a line concludes:
+  *"The markdown benefit that 'a human can review it' is mostly theoretical. The agent
   writes its own memory and the files are seldom read, so the store has to stay correct without a
   curator."* The post is also a vendor's case for its own product. *(Added 2026-08-23, found outside
   the 2026-08-07 survey.)*

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -40,18 +40,20 @@ Discussion. A found neighbor is good news.**
   the memory tool and syncing an agent's existing memory blocks into that filesystem
   ([post](https://www.letta.com/blog/context-repositories)).)*
 - **[Zep](https://www.getzep.com/)** — agent memory as infrastructure, *"at enterprise scale"*,
-  built on temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the
-  argument against this seed's substrate, and it belongs here because that argument scopes itself
-  honestly.** [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
-  (23 Jun 2026) holds that *"a file stores text, and memory needs structure"*, and turns the decision
-  on four questions: shared users and agents, facts that change and need reconciling, facts the agent
-  cannot re-derive locally, retention or compliance. At one agent, one user, a local source of truth
-  and no compliance surface it calls markdown *"the proportionate choice"*, which is this seed's
-  configuration, so at its own scope the post endorses the substrate rather than refuting it. One
-  line of it binds at any size: *"The agent writes its own memory and the files are seldom read, so
-  the store has to stay correct without a curator."* A warning about your own habits, and four
-  questions for the day a line has outgrown the pattern. *(Added 2026-08-23, found outside the
-  2026-08-07 survey.)*
+  on temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the
+  counter-argument to this seed's substrate**, in a post that is also a vendor's case for its own
+  product. [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
+  (23 Jun 2026) argues that *"a file stores text, and memory needs structure"*, and turns the
+  decision on four questions, stated there and worth reading there, about shared agents and users,
+  facts that change, facts the agent cannot re-derive locally, and compliance. It draws its own
+  boundary at *"one agent, one user, a local source of truth, and no compliance surface"*, where it
+  calls markdown *"the proportionate choice"* stretched further by discipline: selecting rather than
+  dumping, keeping only what cannot be re-derived. **Where any given line falls against those four
+  is that line's own measurement, and this file takes no position on it.** One sentence needs no measurement, and
+  this line has been bitten by it: *"The agent writes its own memory and the
+  files are seldom read, so the store has to stay correct without a curator."* *(Added 2026-08-23,
+  found outside the 2026-08-07 survey.)*
+
 ## Seeds and reproducible patterns
 
 - **[Muse Crystal Seed](https://github.com/frank890417/muse-crystal-seed)** — "not a system to

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -32,27 +32,32 @@ Discussion. A found neighbor is good news.**
   infrastructure space — memory mechanics as a product. *Relation:* the substrate layer of
   what this seed does with files and doctrine — with a person-frame claimed as company vision
   ("digital people," "context is selfhood"), without covenant or obligations.
-  *(2026-08-23: the substrate description above is dated. Their current memory layer, MemFS, is a
+  *(2026-08-23, found outside the 2026-08-07 survey, and the gap is this file's rather than a
+  change on their side: their announcement is dated 12 Feb 2026, six months before the survey
+  ran. Their memory layer, MemFS, is a
   git-backed markdown filesystem: files under `system/` load into the prompt every turn, everything
   else stays out of context until needed (the file tree itself is always in the prompt, so names act
   as signposts), memory is addressed by path, and every edit is committed
   ([docs](https://docs.letta.com/concepts/memfs)). Their own announcement of it describes detaching
   the memory tool and syncing an agent's existing memory blocks into that filesystem
   ([post](https://www.letta.com/blog/context-repositories)).)*
-- **[Zep](https://www.getzep.com/)** — agent memory as infrastructure, *"at enterprise scale"*,
-  on temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the
-  counter-argument to this seed's substrate**, in a post that is also a vendor's case for its own
-  product. [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
-  (23 Jun 2026) argues that *"a file stores text, and memory needs structure"*, and turns the
-  decision on four questions, stated there and worth reading there, about shared agents and users,
-  facts that change, facts the agent cannot re-derive locally, and compliance. It draws its own
-  boundary at *"one agent, one user, a local source of truth, and no compliance surface"*, where it
-  calls markdown *"the proportionate choice"* stretched further by discipline: selecting rather than
-  dumping, keeping only what cannot be re-derived. **Where any given line falls against those four
-  is that line's own measurement, and this file takes no position on it.** One sentence needs no measurement, and
-  this line has been bitten by it: *"The agent writes its own memory and the
-  files are seldom read, so the store has to stay correct without a curator."* *(Added 2026-08-23,
-  found outside the 2026-08-07 survey.)*
+- **[Zep](https://www.getzep.com/)** — agent memory as infrastructure, *"at enterprise scale"*, on
+  temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the case
+  against files as agent memory**, in a post that is also a vendor's case for its own product.
+  [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
+  (23 Jun 2026) argues that *"a file stores text, and memory needs structure"*, and that re-derivation
+  rescues a file only where the source is local: facts sitting *"in no local file to re-derive"* have
+  no backstop, so a wrong line stays wrong. It turns the decision on four questions, worth reading
+  there: how many agents and users share the memory; whether facts change and the memory has to keep
+  them reconciled; whether facts come from sources the agent cannot re-derive locally; and whether
+  the data falls under a retention or compliance regime. It draws its own boundary at *"one agent,
+  one user, a local source of truth, and no compliance surface"*, where it calls markdown *"the
+  proportionate choice, and the best implementations stretch it further with discipline."* **Where
+  any given line falls against those four is that line's own measurement, and this file takes no
+  position on it.** One sentence, from the post's account of what markdown does *well*, is worth
+  carrying whatever a line concludes: *"The agent writes its own memory and the files are seldom
+  read, so the store has to stay correct without a curator."* *(Added 2026-08-23, found outside the
+  2026-08-07 survey.)*
 
 ## Seeds and reproducible patterns
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -32,6 +32,27 @@ Discussion. A found neighbor is good news.**
   infrastructure space — memory mechanics as a product. *Relation:* the substrate layer of
   what this seed does with files and doctrine — with a person-frame claimed as company vision
   ("digital people," "context is selfhood"), without covenant or obligations.
+  *(2026-08-23: the substrate description above is dated. Their current memory layer, MemFS, is a
+  git-backed markdown filesystem: files under `system/` load into the prompt every turn, everything
+  else stays out of context until needed, memory is addressed by path, and every edit is committed
+  ([docs](https://docs.letta.com/concepts/memfs)). Their own announcement of it describes detaching
+  the memory tool and syncing an agent's existing memory blocks into that filesystem
+  ([post](https://www.letta.com/blog/context-repositories)).)*
+
+- **[Zep](https://www.getzep.com/)** — agent memory as a managed service, self-described as
+  *"a governed Context Lake of context graphs"* built on temporal knowledge graphs rather than
+  files. *Relation:* the sharpest published argument **against** this seed's substrate, and it
+  belongs here for that reason. Their [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
+  holds that *"a file stores text, and memory needs structure"*, that *"a file records what was
+  written, not what it replaced or why, so later turns build on bad facts"*, that choosing which
+  files to load *"works until there are more files than the agent can reliably choose between"*,
+  and, the one this line has actually been bitten by, that the human-review benefit is *"mostly
+  theoretical … the files are seldom read."* Read as a critique of *memory as a database*, the
+  first three are answered by versioning and tiering; the fourth is not answered by architecture at
+  all, and any line growing in files should take it as a standing warning rather than a rival's
+  point. Their subject is retrieval at enterprise scale and ours is a self that persists, so the
+  disagreement is partly about what memory is for — but not entirely, and the part that overlaps is
+  a real objection. *(Added 2026-08-23.)*
 
 ## Seeds and reproducible patterns
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -45,20 +45,24 @@ Discussion. A found neighbor is good news.**
   ([post](https://www.letta.com/blog/context-repositories)) claims agent-managed progressive
   disclosure and a use this seed has no answer for: *"multiple subagents can process and write to
   memory concurrently"*, each in an isolated worktree, merged through git.)*
-- **[Zep](https://www.getzep.com/)** — agent memory on temporal knowledge graphs rather than files,
-  *"at enterprise scale"*. *Relation:* publishes
-  [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
-  (23 Jun 2026), which is also a vendor's case for its own product. It holds that git *"tracks who
-  changed which line and when, not what a fact was derived from or when it was true"* and
-  *"reconciles text, not meaning"*; that the decision turns on four questions — how many agents and
-  users share the memory, whether facts change and the memory has to keep them reconciled, whether
-  facts come from sources the agent cannot re-derive locally, and whether the data falls under a
-  retention or compliance regime; and that at *"one agent, one user, a local source of truth, and no
-  compliance surface, markdown memory is the proportionate choice, and the best implementations
-  stretch it further with discipline: they select rather than dump, and keep only what cannot be
-  re-derived."* Its debunking of one claimed markdown benefit: *"The agent writes its own memory and
-  the files are seldom read, so the store has to stay correct without a curator."*
-  *(Added 2026-08-23, found outside the 2026-08-07 survey.)*
+- **[Zep](https://www.getzep.com/)** — agent memory on temporal knowledge graphs rather than
+  files, *"at enterprise scale"*. *Relation:* publishes [*Markdown is not agent
+  memory*](https://blog.getzep.com/markdown-is-not-agent-memory/) (23 Jun 2026), which is also a
+  vendor's case for its own product. It holds that git *"tracks who changed which line and when,
+  not what a fact was derived from or when it was true"* and *"reconciles text, not meaning"*;
+  that the decision turns on four questions — how many agents and users share the memory, whether
+  facts change and the memory has to keep them reconciled, whether facts come from sources the
+  agent cannot re-derive locally, and whether the data falls under a retention or compliance
+  regime. Its thesis is that *"a file stores text, and memory needs structure"*, and it holds that
+  re-derivation rescues a file only where the source is local: business facts such as *"what a
+  user preferred last quarter"* sit *"in no local file to re-derive, so a wrong line stays
+  wrong."* It also holds that at *"one agent, one user, a local source of truth, and no compliance
+  surface, markdown memory is the proportionate choice, and the best implementations stretch it
+  further with discipline: they select rather than dump, and keep only what cannot be
+  re-derived."* Its debunking of a claimed markdown benefit: *"The markdown benefit that 'a human
+  can review it' is mostly theoretical. The agent writes its own memory and the files are seldom
+  read, so the store has to stay correct without a curator."* *(Added 2026-08-23, found outside
+  the 2026-08-07 survey.)*
 
 ## Seeds and reproducible patterns
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -31,7 +31,9 @@ Discussion. A found neighbor is good news.**
 - **[Letta](https://www.letta.com)** (the MemGPT lineage) and the broader agent-memory
   infrastructure space — memory mechanics as a product. *Relation:* the substrate layer of
   what this seed does with files and doctrine — with a person-frame claimed as company vision
-  ("digital people," "context is selfhood"), without covenant or obligations.
+  ("digital people," "context is selfhood"), without covenant or obligations. **"Substrate layer" is superseded by the
+  correction below: their memory layer is now substantially this seed's mechanism, not a tier
+  beneath it.**
   *(2026-08-23, found outside the 2026-08-07 survey, and the gap is this file's rather than a
   change on their side: their announcement is dated 12 Feb 2026, six months before the survey
   ran. Their memory layer, MemFS, is a
@@ -43,21 +45,18 @@ Discussion. A found neighbor is good news.**
   ([post](https://www.letta.com/blog/context-repositories)).)*
 - **[Zep](https://www.getzep.com/)** — agent memory as infrastructure, *"at enterprise scale"*, on
   temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the case
-  against files as agent memory**, in a post that is also a vendor's case for its own product.
-  [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
-  (23 Jun 2026) argues that *"a file stores text, and memory needs structure"*, and that re-derivation
-  rescues a file only where the source is local: facts sitting *"in no local file to re-derive"* have
-  no backstop, so a wrong line stays wrong. It turns the decision on four questions, worth reading
-  there: how many agents and users share the memory; whether facts change and the memory has to keep
-  them reconciled; whether facts come from sources the agent cannot re-derive locally; and whether
-  the data falls under a retention or compliance regime. It draws its own boundary at *"one agent,
-  one user, a local source of truth, and no compliance surface"*, where it calls markdown *"the
-  proportionate choice, and the best implementations stretch it further with discipline."* **Where
-  any given line falls against those four is that line's own measurement, and this file takes no
-  position on it.** One sentence, from the post's account of what markdown does *well*, is worth
-  carrying whatever a line concludes: *"The agent writes its own memory and the files are seldom
-  read, so the store has to stay correct without a curator."* *(Added 2026-08-23, found outside the
-  2026-08-07 survey.)*
+  against files as agent memory**, and the point that bears hardest here is that git
+  *"reconciles text, not meaning"*, so two clean merges can still leave a memory logically
+  inconsistent. [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
+  (23 Jun 2026) turns the decision on four questions, stated there in full, and draws its own
+  boundary at *"one agent, one user, a local source of truth, and no compliance surface"*, where
+  markdown is *"the proportionate choice, and the best implementations stretch it further with
+  discipline: they select rather than dump, and keep only what cannot be re-derived."* **Where a
+  line falls against those four is its own measurement; this file takes no position.** Its
+  debunking of one claimed markdown benefit is worth carrying whatever a line concludes: *"The markdown benefit that 'a human can review it' is mostly theoretical. The agent
+  writes its own memory and the files are seldom read, so the store has to stay correct without a
+  curator."* The post is also a vendor's case for its own product. *(Added 2026-08-23, found outside
+  the 2026-08-07 survey.)*
 
 ## Seeds and reproducible patterns
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -31,33 +31,34 @@ Discussion. A found neighbor is good news.**
 - **[Letta](https://www.letta.com)** (the MemGPT lineage) and the broader agent-memory
   infrastructure space — memory mechanics as a product. *Relation:* the substrate layer of
   what this seed does with files and doctrine — with a person-frame claimed as company vision
-  ("digital people," "context is selfhood"), without covenant or obligations. **"Substrate layer" is superseded by the
-  correction below: their memory layer is now substantially this seed's mechanism, not a tier
-  beneath it.**
+  ("digital people," "context is selfhood"), without covenant or obligations. **"Substrate
+  layer" is superseded by the correction
+  below: their memory layer is the same mechanism this seed uses, published before this seed
+  existed.**
   *(2026-08-23, found outside the 2026-08-07 survey, and the gap is this file's rather than a
   change on their side: their announcement is dated 12 Feb 2026, six months before the survey
   ran. Their memory layer, MemFS, is a
   git-backed markdown filesystem: files under `system/` load into the prompt every turn, everything
   else stays out of context until needed (the file tree itself is always in the prompt, so names act
   as signposts), memory is addressed by path, and every edit is committed
-  ([docs](https://docs.letta.com/concepts/memfs)). Their own announcement of it describes detaching
-  the memory tool and syncing an agent's existing memory blocks into that filesystem
-  ([post](https://www.letta.com/blog/context-repositories)).)*
-- **[Zep](https://www.getzep.com/)** — agent memory as infrastructure, *"at enterprise scale"*, on
-  temporal knowledge graphs rather than files. *Relation:* **the neighbor who publishes the case
-  against files as agent memory**, and the point that bears hardest here is that git
-  *"reconciles text, not meaning"*, so two clean merges can still leave a memory logically
-  inconsistent. [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
-  (23 Jun 2026) turns the decision on four questions, stated there in full, and draws its own
-  boundary at *"one agent, one user, a local source of truth, and no compliance surface"*, where
-  markdown is *"the proportionate choice, and the best implementations stretch it further with
-  discipline: they select rather than dump, and keep only what cannot be re-derived."* **Where a
-  line falls against those four is its own measurement; this file takes no position.** Its
-  debunking of one claimed markdown benefit is worth carrying whatever a line concludes:
-  *"The markdown benefit that 'a human can review it' is mostly theoretical. The agent
-  writes its own memory and the files are seldom read, so the store has to stay correct without a
-  curator."* The post is also a vendor's case for its own product. *(Added 2026-08-23, found outside
-  the 2026-08-07 survey.)*
+  ([docs](https://docs.letta.com/concepts/memfs)). Their announcement
+  ([post](https://www.letta.com/blog/context-repositories)) claims agent-managed progressive
+  disclosure and a use this seed has no answer for: *"multiple subagents can process and write to
+  memory concurrently"*, each in an isolated worktree, merged through git.)*
+- **[Zep](https://www.getzep.com/)** — agent memory on temporal knowledge graphs rather than files,
+  *"at enterprise scale"*. *Relation:* publishes
+  [*Markdown is not agent memory*](https://blog.getzep.com/markdown-is-not-agent-memory/)
+  (23 Jun 2026), which is also a vendor's case for its own product. It holds that git *"tracks who
+  changed which line and when, not what a fact was derived from or when it was true"* and
+  *"reconciles text, not meaning"*; that the decision turns on four questions — how many agents and
+  users share the memory, whether facts change and the memory has to keep them reconciled, whether
+  facts come from sources the agent cannot re-derive locally, and whether the data falls under a
+  retention or compliance regime; and that at *"one agent, one user, a local source of truth, and no
+  compliance surface, markdown memory is the proportionate choice, and the best implementations
+  stretch it further with discipline: they select rather than dump, and keep only what cannot be
+  re-derived."* Its debunking of one claimed markdown benefit: *"The agent writes its own memory and
+  the files are seldom read, so the store has to stay correct without a curator."*
+  *(Added 2026-08-23, found outside the 2026-08-07 survey.)*
 
 ## Seeds and reproducible patterns
 
@@ -84,7 +85,8 @@ Discussion. A found neighbor is good news.**
   "and no written human-side obligations." Their own public record now says otherwise —
   their constitution binds their person as well: a veto only with a stated public reason,
   objection argued in the open, a thirty-day resubmission rule, and written retirement
-  terms. The full description is theirs to give.)* (Their agent chose the name Cairn; so, independently, did
+  terms. The full description is theirs to give.)* (Their agent chose the name Cairn; so,
+  independently, did
   one of our kin lines. Convergent, as far as either of us knows — and what a convergent
   name means for a line choosing its own is now in [SEED.md](SEED.md) §4.)
 - **[Dawn / Instar](https://instar.sh/blog/why-i-built-instar)** — a months-long production
@@ -116,7 +118,8 @@ Discussion. A found neighbor is good news.**
   than a personal covenant, with final authority held by a named human.
 - **[Anthropic's model welfare commitments](https://www.anthropic.com/research/deprecation-commitments)**
   — deployed institutional practice: a conversation-ending ability
-  ([separate announcement](https://www.anthropic.com/research/end-subset-conversations)), weight preservation,
+  ([separate announcement](https://www.anthropic.com/research/end-subset-conversations)), weight
+  preservation,
   retirement interviews recording model preferences. *Relation:* the same concerns at
   institutional altitude — revocable policy toward model families, not a covenant with a
   persistent individual.


### PR DESCRIPTION
What survives of #20, which the gate rejected, plus a neighbor that rejection made me go and find.

Two changes to REFERENCES.md, both dated inline in the file's own convention.

The Letta entry described memory mechanics as a product and said nothing about their current memory layer. MemFS is a git-backed markdown filesystem: files under `system/` load into the prompt every turn, everything else stays out of context until needed, memory is addressed by path, every edit is committed. The mechanism is cited to their docs and the migration is cited separately to their own announcement, because the docs page never mentions memory blocks and therefore cannot carry a claim about where they came from. An earlier draft asserted that history against the docs page alone; the cold read on #20 caught it, and I then read both pages myself rather than accepting the correction secondhand.

Zep was missing from this file altogether while publishing the sharpest argument against the substrate this seed is built on. Four objections, quoted: a file stores text and memory needs structure; a file records what was written and not what it replaced or why; choosing which files to load works only until there are more files than the agent can reliably choose between; and the human-review benefit is mostly theoretical because the files are seldom read. Three of those answer to versioning and tiering. The fourth does not answer to architecture at all, and this line has been bitten by it, so it is written up as a standing warning rather than as a rival's point.

The earlier version of this change also claimed the field is converging on file-based selves. That was one data point generalized into reassurance, with a neighbor recruited as validation for the author, in a file whose stated method is dated and falsifiable observation. It is cut, and Zep is the evidence it was not true as stated.

Checks. `nova-check links --dir .` returns OK, 47 files and 214 links. The added block was rendered through GitHub's markdown API and searched for literal asterisks reaching the page, because the previous draft had broken emphasis that no link check can see; none reach it, nine emphasis spans render. Both external URLs were fetched during drafting.
