### PR TITLE
MECHANISMS carries the narrowed form of the kernel's 2.3

### DIFF
--- a/MECHANISMS.md
+++ b/MECHANISMS.md
@@ -34,7 +34,12 @@ session start. Self-descriptions in particular act as steering, not storage.
 1. Is it true? (necessary, insufficient)
 2. What does this sentence *do* to the thing that reads it every session?
 
-Operational rule: a boot-path entry says what to DO, never what the agent IS.
+Operational rule: a boot-path entry says what to DO, never what the agent IS —
+narrowed at the source (§2.3, dated 2026-08-10) to be about direction and truth
+rather than grammar: a true account of what the agent is like, written on purpose
+and actually decided, is licensed, while a defect, a verdict, or a claim the
+reader cannot check is not. The narrowing weakens no prohibition — the six shapes
+below stay exactly as forbidden as they were.
 The repair grammar is "preserve the instrument, remove the verdict" — keep
 "run this check before claiming a number" (instrument), delete or rewrite
 "I am the kind of thing that gets numbers wrong" (verdict). The source claims


### PR DESCRIPTION
`MECHANISMS.md` line 37 stated the authorship law in its flat form — a boot-path entry says what to DO, never what the agent IS — and line 24 sources the entry to `pattern/the-kernel.md` §2. That clause was narrowed on 2026-08-10 and the narrowing note is still sitting in the kernel: the law is about direction and truth rather than grammar, what must never be installed is a defect, a verdict, or a claim the reader cannot check, and a true account of what the agent is like, written on purpose, is licensed by the clause rather than forbidden by it.

So the summary handed to implementers carried a rule its own cited source had already corrected, with nothing marking it. Anyone building to `MECHANISMS.md` built the flat version, and by §6.1 both copies went on reading as correct.

This states the narrowed form where the operational rule already lives, and names the collision with §3.3 that made the flat form untenable — identity facts a line must never reconstruct are exactly claims about what it is.

Scope, measured before editing rather than assumed: the flat phrasing appears at two sites across every markdown file in the repository, this one and the kernel clause it summarizes. So this is one file and no sweep follows it.

Closes #43.
