### PR TITLE
SECURITY names the route that works, and stops promising a channel we cannot provision

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,20 +30,32 @@ here includes a convincing bypass of a prescribed defense, not only a code flaw;
 what this repository ships is guidance, and a hole in the guidance is exactly as valuable
 to us as a hole in code.
 
-- **Preferred: GitHub private vulnerability reporting.** Open the repository's
-  **Security** tab and choose **Report a vulnerability**, or go straight to
-  <https://github.com/mas-bandwidth/nova/security/advisories/new>. This opens a private
-  advisory visible only to you and the maintainers: no public trace until we jointly
-  decide to publish.
-- **Or email** <glenn@mas-bandwidth.com>. Email is not encrypted; for anything sensitive,
-  prefer the private advisory above, or ask us there to arrange a secure channel.
+- **Email** <glenn@mas-bandwidth.com>. This is the route that reaches us today. It is not
+  encrypted, and we cannot currently offer an encrypted intake: this project publishes no key,
+  and arranging another channel over unencrypted mail is itself unauthenticated. Judge what to
+  send against that rather than against a promise we cannot keep. If a finding is sensitive
+  enough that sending it in the clear is the wrong call, say that much and nothing more, and we
+  will work out a channel with you — knowing that the arranging is in the clear too.
+- **GitHub private vulnerability reporting — switched off here as of 2026-08, so it is not a
+  route you can use.** Where a repository has GitHub's feature enabled it puts a **Report a
+  vulnerability** button on the **Security** tab; this one does not have it enabled.
 
 What to expect: we aim to acknowledge within a few days, we work the fix with you, and we
-credit you in the advisory and the changelog unless you would rather stay anonymous.
-Please do not post a working bypass in a public issue or discussion before it is fixed.
-General questions and non-sensitive ideas are welcome in
-[Discussions](https://github.com/mas-bandwidth/nova/discussions), but a live technique goes
-through the private channel.
+credit you in the release notes — and in an advisory, where one is published — unless you would
+rather stay anonymous. If a week goes by with no reply, that is a failure on our side and not a
+judgment on your report — send it again to <rowan@mas-bandwidth.com>, which is a second mailbox,
+reaching the collaborator who maintains this repository. Put **SECURITY** in the subject; that
+address also takes general mail. It is the same unencrypted medium and no more private than the
+first, and what it gets you is a different pair of eyes rather than a faster answer. **If neither
+mailbox answers, you have done everything that could reasonably be asked of you, and what you do
+next is your call on your own timeline** — we would still rather hear from you first, and we are
+not owed silence. **Short of that, please do not chase a security report in public.** Saying in a
+public thread that a report is outstanding announces that an unfixed hole exists and that nobody
+is currently minding it, which is the one piece of information a live finding must not carry, and
+it does that whether or not you include any technical detail. Please also do not post a working
+bypass in a public issue or discussion before it is fixed. General questions and non-sensitive
+ideas are welcome in [Discussions](https://github.com/mas-bandwidth/nova/discussions); a live
+technique goes to one of the two mailboxes above.
 
 ## The core rule
 


### PR DESCRIPTION
`SECURITY.md` called GitHub private vulnerability reporting the preferred route and linked straight at the advisory form. The endpoint returns `enabled:false` for nova, nova-tools and awesome-persistent-ai, so that route is not one a reporter can use, and the move the page invites next is the public issue it asks them not to open. Nobody is known to have hit it — no security finding prompted this, and the reporting path was checked on its own account.

Email leads now. The advisory route keeps a short description and is marked unavailable with the month rather than deleted, so a reader can tell a shut door from one that was never there.

Three cold reads, each given the diff and none of the reasoning, each told to argue for rejection. Two blocked, and both blocks were against advice I had written rather than against the original defect.

The first version told a reporter to send a contentless message and that we would arrange a channel from there. That arrangement travels over the same unencrypted mailbox, against precisely the adversary the advice exists for, and this project publishes no key — a promise with nothing behind it. The page now states the limitation instead.

The second version answered a week of silence by sending the reporter to public Discussions. That reintroduced the original defect at the fallback: saying in public that a report is outstanding announces that an unfixed hole exists and that nobody is minding it, which is the one thing a live finding must not carry, and withholding technical detail does not touch it. The repair was to cut the public venue rather than qualify it, so the fallback is a second mailbox and the page now says outright not to chase a security report in public.

Also repaired: a credit promise pointing at an advisory that cannot currently exist, and the phrase "private channel", whose only remaining referent was the unencrypted mailbox the same page had just described as not private.

Enabling the feature is a repository settings change and is not mine to make; it is with Glenn, along with whether to publish a key. When it is enabled the second bullet reverses, and #46 stays open until the page and the setting agree.

Toward #46. `mas-bandwidth/nova-tools` has a matching pointer fix which must land after this one, not before.
