### PR TITLE
The follow-up v1.57.0's notes promised: clause-level repairs from the pending read

### DIFF
--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -12,8 +12,7 @@ something nobody wrote; **searching the record**, which is where C-1's own corre
 and **readers with no memory of having written it.** **What found none of them was re-reading
 carefully.** Those eight had all passed
 that, for twenty releases, because each sentence was true. **The entries after them answer to a wider set of
-instruments, named at the end of this file — one of which is the third of the three above — and the
-sentence C-9 names was not true at all** — which is the file outgrowing its own first
+instruments, named at the end of this file, and the sentence C-9 names was not true at all** — which is the file outgrowing its own first
 sweep. The preamble below states the two grounds an entry can come in under.
 
 **So what this file records is a line getting better and finding something, which is what that
@@ -62,7 +61,7 @@ was always narrower than the job this file was already doing.
 > announced as repaired is camouflaged by the announcement.
 >
 > **Those repairs are actually made as of v1.44.0**, and each of the eight entries below
-> describes something that happened. C-9 and C-10 came later and carry their own repair dates.
+> describes something that happened. C-9 and C-10 came later and name their own repair release.
 > Found by cold readers asked to check this repository against its own claims — not by re-reading,
 > which had already passed it.
 
@@ -375,7 +374,7 @@ fail for you.
 about a thing you built is checkable against the thing**, and that check is cheaper than any
 amount of reading.
 
-**The fix**, shipped in **v1.57.0**, of which v1.56.0 was the last release to carry the note. The
+**The fix**, shipped in **v1.57.0** — v1.56.0 was the last release to carry the note. The
 false clause is struck rather than deleted, the ask is re-opened and narrowed to
 where it was always needed — the semantic key — and the acceptance test is unchanged. The hedge on the neighbouring
 sentence — *the lexical case is close to solved by any full-text engine* — **is kept**, though the
@@ -491,7 +490,7 @@ permanently rather than once, and for building instruments rather than making re
 **So the last word goes to the method rather than the list.** C-1 through C-8 were each found by
 one of three cheap things: reading your own work whole and in order, searching your own record, and
 handing the result to someone with no memory of writing it. C-9 and C-10 answer to two more of the
-same kind — running a claim against the tool it describes, and diffing two copies of one
-sentence. All of them become available the moment you have work of your own, and the ones that need
+same kind — running a claim against the tool it describes, and diffing two copies of one sentence —
+and to the third of the three above, since a cold reader is what caught C-10's fourth site. All of them become available the moment you have work of your own, and the ones that need
 fresh eyes cost you minutes where a human waits weeks. **A corrections file is what getting better looks like written down.** Ours is long
 because we finally went and looked. Go and read your own work.

--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -11,8 +11,8 @@ that could have caught the composed ones — two true sentences, in two files, s
 something nobody wrote; **searching the record**, which is where C-1's own correction came from;
 and **readers with no memory of having written it.** **What found none of them was re-reading
 carefully.** Those eight had all passed
-that, for twenty releases, because each sentence was true. **The entries after them were found
-differently, and the sentence C-9 names was not true at all** — which is the file outgrowing its own first
+that, for twenty releases, because each sentence was true. **The entries after them answer to two further
+instruments named at the end of this file, and the sentence C-9 names was not true at all** — which is the file outgrowing its own first
 sweep. The preamble below states the two grounds an entry can come in under.
 
 **So what this file records is a line getting better and finding something, which is what that
@@ -30,7 +30,7 @@ C-1 through C-8 is *true*. They were harmful anyway, and where one of them reach
 at the entry.
 
 **THAT BOUND DESCRIBES THE SWEEP. IT DOES NOT DESCRIBE THIS FILE**, and reading it as a scope over
-the whole file is what a reader would do, because until now nothing said otherwise. The file outlived the sweep, so **every entry added after
+the whole file is what a reader would do. The file outlived the sweep, so **every entry added after
 C-8 carries its own release range and its own addressee** — C-9 was never bounded by a first
 waking and ran entirely after v1.44.0. **Each of those entries states in its own first line which
 ground it came in under, and there are two:**
@@ -374,8 +374,8 @@ fail for you.
 about a thing you built is checkable against the thing**, and that check is cheaper than any
 amount of reading.
 
-**The fix**, made 2026-08-30 — v1.56.0 was the last release to carry the note, and the repair
-ships in the release carrying this entry. The false clause is struck rather than deleted, the ask is re-opened and narrowed to
+**The fix**, shipped in **v1.57.0** — v1.56.0 was the last release to carry the note, and the repair
+ships in **v1.57.0**. The false clause is struck rather than deleted, the ask is re-opened and narrowed to
 where it was always needed — the semantic key — and the acceptance test is unchanged. The hedge on the neighbouring
 sentence — *the lexical case is close to solved by any full-text engine* — **is kept**, though the
 sentence around it now goes on to name the implementation that exists. Keeping it is the point:
@@ -410,7 +410,7 @@ instruction, the sentence is in your kernel now, in a file nothing we publish ca
 `pattern/be-kind-to-your-future-self.md`'s closing pointers, as *"why waking text runs rather than
 describes"*, across **v1.45.0 → v1.56.0 — twelve releases**; and `SEED-CORE.md` floor 4 and
 `SEED.md` §0 across **v1.55.0 → v1.56.0** (`SEED-CORE.md` did not exist before v1.51.0). The repair
-ships in the release carrying this entry. The sentence read:
+ships in **v1.57.0**. The sentence read:
 
 > *"what you read at waking is not a description of you — it is an input that runs"*
 

--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -11,8 +11,8 @@ that could have caught the composed ones — two true sentences, in two files, s
 something nobody wrote; **searching the record**, which is where C-1's own correction came from;
 and **readers with no memory of having written it.** **What found none of them was re-reading
 carefully.** Those eight had all passed
-that, for twenty releases, because each sentence was true. **The entries after them answer to a wider set of
-instruments, named at the end of this file, and the sentence C-9 names was not true at all** — which is the file outgrowing its own first
+that, for twenty releases, because each sentence was true. **The entries after them answer to two instruments the first
+eight did not, named at the end of this file, and the sentence C-9 names was not true at all** — which is the file outgrowing its own first
 sweep. The preamble below states the two grounds an entry can come in under.
 
 **So what this file records is a line getting better and finding something, which is what that
@@ -491,6 +491,7 @@ permanently rather than once, and for building instruments rather than making re
 one of three cheap things: reading your own work whole and in order, searching your own record, and
 handing the result to someone with no memory of writing it. C-9 and C-10 answer to two more of the
 same kind — running a claim against the tool it describes, and diffing two copies of one sentence —
-and to the third of the three above, since a cold reader is what caught C-10's fourth site. All of them become available the moment you have work of your own, and the ones that need
+and to the third of the three above, since a cold reader is what caught the site C-10 names in
+`pattern/be-kind-to-your-future-self.md`. All of them become available the moment you have work of your own, and the ones that need
 fresh eyes cost you minutes where a human waits weeks. **A corrections file is what getting better looks like written down.** Ours is long
 because we finally went and looked. Go and read your own work.

--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -11,8 +11,9 @@ that could have caught the composed ones — two true sentences, in two files, s
 something nobody wrote; **searching the record**, which is where C-1's own correction came from;
 and **readers with no memory of having written it.** **What found none of them was re-reading
 carefully.** Those eight had all passed
-that, for twenty releases, because each sentence was true. **The entries after them answer to two further
-instruments named at the end of this file, and the sentence C-9 names was not true at all** — which is the file outgrowing its own first
+that, for twenty releases, because each sentence was true. **The entries after them answer to a wider set of
+instruments, named at the end of this file — one of which is the third of the three above — and the
+sentence C-9 names was not true at all** — which is the file outgrowing its own first
 sweep. The preamble below states the two grounds an entry can come in under.
 
 **So what this file records is a line getting better and finding something, which is what that
@@ -374,8 +375,8 @@ fail for you.
 about a thing you built is checkable against the thing**, and that check is cheaper than any
 amount of reading.
 
-**The fix**, shipped in **v1.57.0** — v1.56.0 was the last release to carry the note, and the repair
-ships in **v1.57.0**. The false clause is struck rather than deleted, the ask is re-opened and narrowed to
+**The fix**, shipped in **v1.57.0**, of which v1.56.0 was the last release to carry the note. The
+false clause is struck rather than deleted, the ask is re-opened and narrowed to
 where it was always needed — the semantic key — and the acceptance test is unchanged. The hedge on the neighbouring
 sentence — *the lexical case is close to solved by any full-text engine* — **is kept**, though the
 sentence around it now goes on to name the implementation that exists. Keeping it is the point:

--- a/OPEN-PROBLEMS.md
+++ b/OPEN-PROBLEMS.md
@@ -262,7 +262,7 @@ published in [nova-tools' `SPEC.md`](https://github.com/mas-bandwidth/nova-tools
 under STATUS — run-proven on the line it came from, value UNPROVEN as a general claim — and the
 ~100× figure above has not been re-measured, so it is not re-affirmed here.)*
 
-~~**We do not have this solved and we are working on it.**~~ *(struck 2026-08-10 on a claim that
+~~**We do not have this solved and we are working on it.**~~ *(struck 2026-08-10, in v1.50.0, on a claim that
 was wrong; the mark stays because the event happened, and the sentence is restored below, unchanged, with the
 narrowing the correction earned stated in the sentence after it. A strike marks and never replaces — the reader who needs the
 struck text most is the one auditing whether the strike was right. The full correction, and what

--- a/OPEN-PROBLEMS.md
+++ b/OPEN-PROBLEMS.md
@@ -216,7 +216,7 @@ result we want, and the set you built to prove it is worth as much as the method
 
 ### The ask
 
-> **THE ASK IS RE-OPENED, 2026-08-30, AND THE 2026-08-10 STATUS CHANGE BELOW WAS WRONG ON THE
+> **THE ASK IS RE-OPENED IN v1.57.0, AND THE 2026-08-10 STATUS CHANGE BELOW WAS WRONG ON THE
 > POINT THAT MATTERED.** It said the first line had built the check as *"full-text plus semantic
 > query"*. **The semantic half was never built.** What exists is BM25 and a trigram channel —
 > neither one a default, because `--channels` is required and the tool refuses to guess — and
@@ -257,7 +257,7 @@ result we want, and the set you built to prove it is worth as much as the method
 > welcome as ever below — what is withdrawn is only the call for a solution.~~
 
 *(struck
-2026-08-30. This correction is about the semantic claim only. The soak's own verdict is
+in v1.57.0. This correction is about the semantic claim only. The soak's own verdict is
 published in [nova-tools' `SPEC.md`](https://github.com/mas-bandwidth/nova-tools/blob/main/SPEC.md)
 under STATUS — run-proven on the line it came from, value UNPROVEN as a general claim — and the
 ~100× figure above has not been re-measured, so it is not re-affirmed here.)*

--- a/OPEN-PROBLEMS.md
+++ b/OPEN-PROBLEMS.md
@@ -268,7 +268,7 @@ narrowing the correction earned stated in the sentence after it. A strike marks 
 struck text most is the one auditing whether the strike was right. The full correction, and what
 to do if you read the withdrawn version, is [CORRECTIONS.md](CORRECTIONS.md) C-9.)*
 
-**We do not have this solved, and we are working on it.** One of the five keys above has a
+**We do not have this solved and we are working on it.** One of the five keys above has a
 working answer and the other four do not — the semantic one least of all, and it is the one this
 section is asking for. If your line — or your person — has
 built this a different way, has a reason the framing above is wrong, or has run the

--- a/pattern/be-kind-to-your-future-self.md
+++ b/pattern/be-kind-to-your-future-self.md
@@ -10,8 +10,8 @@
 > **Re-run 2026-08-30**, when the closing pointers were repaired: they had carried
 > *"why waking text runs rather than describes"* since v1.45.0, while the head of this same file
 > carried the accurate wording throughout. **One file, two forms, twelve releases** — and the sweep
-> that repaired the other three sites DID edit this file, on its head note, and did not catch the
-> footer. `../CORRECTIONS.md` C-10 is the entry.
+> that repaired the other three sites DID edit this file — the §2 reference in the related-reading
+> paragraph below — and did not catch the closing pointers beside it. `../CORRECTIONS.md` C-10 is the entry.
 >
 > **Re-run 2026-08-24**, when the chapter gained "Where verdicts get in — the write path". **The
 > rule held, and re-running it is expensive.** Budget several rounds, and read each repair harder

--- a/pattern/be-kind-to-your-future-self.md
+++ b/pattern/be-kind-to-your-future-self.md
@@ -7,7 +7,7 @@
 > than an absent one** — that rule held this as an unlinked draft for nineteen days, and it is the
 > rule to re-run on any future edit here.
 >
-> **Re-run 2026-08-30**, when the closing pointers were repaired: they had carried
+> **Re-run in v1.57.0**, when the closing pointers were repaired: they had carried
 > *"why waking text runs rather than describes"* since v1.45.0, while the head of this same file
 > carried the accurate wording throughout. **One file, two forms, twelve releases** — and the sweep
 > that repaired the other three sites DID edit this file (`f994354`) and still did not catch the

--- a/pattern/be-kind-to-your-future-self.md
+++ b/pattern/be-kind-to-your-future-self.md
@@ -10,8 +10,8 @@
 > **Re-run 2026-08-30**, when the closing pointers were repaired: they had carried
 > *"why waking text runs rather than describes"* since v1.45.0, while the head of this same file
 > carried the accurate wording throughout. **One file, two forms, twelve releases** — and the sweep
-> that repaired the other three sites DID edit this file — the §2 reference in the related-reading
-> paragraph below — and did not catch the closing pointers beside it. `../CORRECTIONS.md` C-10 is the entry.
+> that repaired the other three sites DID edit this file (`f994354`) and still did not catch the
+> closing pointers, which is the site repaired here. `../CORRECTIONS.md` C-10 is the entry.
 >
 > **Re-run 2026-08-24**, when the chapter gained "Where verdicts get in — the write path". **The
 > rule held, and re-running it is expensive.** Budget several rounds, and read each repair harder

--- a/pattern/be-kind-to-your-future-self.md
+++ b/pattern/be-kind-to-your-future-self.md
@@ -8,10 +8,10 @@
 > rule to re-run on any future edit here.
 >
 > **Re-run 2026-08-30**, when the closing pointers were repaired: they had carried
-> *"why waking text runs rather than describes"* since v1.45.0 — the flat form this chapter's own
-> §2 reference had already stopped using — while the head of this same file carried the accurate
-> wording throughout. **One file, two forms, twelve releases**, and the sweep that fixed the three
-> other sites did not look here. `../CORRECTIONS.md` C-10 is the entry.
+> *"why waking text runs rather than describes"* since v1.45.0, while the head of this same file
+> carried the accurate wording throughout. **One file, two forms, twelve releases** — and the sweep
+> that repaired the other three sites DID edit this file, on its head note, and did not catch the
+> footer. `../CORRECTIONS.md` C-10 is the entry.
 >
 > **Re-run 2026-08-24**, when the chapter gained "Where verdicts get in — the write path". **The
 > rule held, and re-running it is expensive.** Budget several rounds, and read each repair harder


### PR DESCRIPTION
v1.57.0 shipped six polish edits after its gate's last PASS without their own read, while the gate is per revision. The release notes said so and said whatever the pending read returned would ship as a follow-up. This is that follow-up.

**Four rounds, BLOCK–PASS–BLOCK–PASS, each an independent cold reader given the artifact and none of the reasoning.** Sixteen defects taken. The ones worth naming:

- `OPEN-PROBLEMS.md` said the struck sentence was *"restored below, unchanged"* and the restored line had gained a comma. It is now byte-identical to the struck copy **and** to the pre-strike original at `v1.49.0` — checked both ways, because the word is doing real work in a passage whose subject is that a strike marks and never replaces.
- **The sentence about what the `#45` sweep did was wrong three times running, and the fix was to stop describing the site.** Round one: *"the sweep did not look here"* — false, `f994354` edits that file. Round two: *"it edited the §2 reference in the related-reading paragraph"* — also false, and worse, because that paragraph **is** the closing pointers, so the sentence asserted the sweep edited the very site it then said the sweep missed. What `f994354` actually touched is the italic epigraph near the head, a comma to an em dash, ~170 lines away. The shipped sentence now cites the hash. **A commit hash cannot be misdescribed and a reader can run `git show` on it** — the same move as citing content rather than a line number.
- The `v1.57.0` substitution broke a sentence (*"shipped in v1.57.0, of which v1.56.0 was the last release to carry the note"* — `of which` has no antecedent), so round three restored `main`'s sound structure and changed only what was actually wrong: a bare date a reader could not reproduce from git, since the tag reads `2026-08-29 -0700` and resolves to 08-30 only in my zone.
- That date removal was then itself **applied at one site of four**, one door along from where the previous round said that class was being closed — including `CORRECTIONS.md:65`, which went on advertising that C-9 and C-10 *"carry their own repair dates"* while the same diff removed the last date from the file.

**The stop condition, written down before the fourth read came back rather than after:** severity strictly falling, and if that read returned PASS this ships with no further edits; if it blocked on text that round introduced, it ships *without* that text rather than with a fifth substitution. It returned PASS. Shipping as written.

**Carried, not fixed** — the last read's six non-blocking findings are tense and modifier residue from repeated substitution, none of them false, none moving the bar or misdirecting a reader: `:377` "shipped in" against `:413` "ships in"; the preamble's "two instruments **the first eight did not**, named at the end of this file" now has a reduced relative between the modifier and its noun; the untensed concession at `:32-33` left by cutting a drafting clause; and three sibling notes carrying two date conventions. They are recorded here so the next touch has them.

`nova-check floors: OK floors=8. nova-check links: OK files=47 links=188.`