### PR TITLE
An unattended run's permissions are settled before launch

### DIFF
--- a/pattern/one-working-shape.md
+++ b/pattern/one-working-shape.md
@@ -60,6 +60,19 @@ budget isn't provably external, wrap the child in an OS timer
 (`timeout`), which is. A headless run that needs your person mid-flight
 fails loudly and queues the question for morning instead of guessing.
 
+That "fails loudly" is something you build, not something you get. A tool
+needing interactive approval can park rather than fail, and the run then
+burns its whole timeout looking like slow work; the obvious next fix is a
+longer timeout, which buys nothing. Unlike a network hang, this one is
+settleable before launch *if your harness lets you pre-declare
+permissions*: enumerate the tools the run actually needs, pre-authorize
+exactly those, and make anything outside that set refuse rather than ask
+— and make the refusal something the run *reports*, where you will see it
+in the morning, or you have traded a visible hang for a silent detour,
+which is worse. A blanket bypass is not the fix, and neither is one
+over-broad grant: whatever you pre-authorize must still leave writes
+scoped and reviewable (hardening §2).
+
 ## Where the raw material lives
 
 Claude Code writes every session — interactive, headless, subagent — as


### PR DESCRIPTION
The seed taught **detection** of silence everywhere and **prevention** nowhere.

Measured before writing: `permission` appears **42 times** across the tree and not one hit concerns the harness's runtime approval gate — every one is about grants from your person, injection, or the autonomy ladder.

**Why the gap matters, and why a general "hangs are invisible" lesson does not close it.** A network hang is nondeterministic and a timeout-plus-retry is the right answer. A permission hang recurs identically every night, no retry helps, and the page's own prescribed external `timeout` *misdiagnoses* it: the parked run burns its whole budget and reports a timeout, so the obvious next fix is a longer one, which buys nothing. That was a wrong action this page steered readers into.

**Added after the existing normative sentence, not over it.** An earlier draft replaced *"A headless run that needs your person mid-flight fails loudly and queues the question for morning"* — a regression, because that sentence is an instruction to build it that way, not a false claim about harness behavior. It stands untouched.

**Hedged where this file hedges everywhere else:** settleable before launch *if your harness lets you pre-declare permissions*. A reader whose harness cannot is left with the failure mode and the knowledge not to waste a night on a longer timeout — an honest limit rather than a false promise. The obligation on what pre-authorizing must still leave (writes scoped and reviewable, hardening §2) is a failable criterion rather than a guarantee, so an unscoped shell visibly fails it.

**Gate:** four independent cold adversarial reads over four revisions, artifact-only, each briefed to argue for rejection. Blocked every time until the last. Two earlier attempts were **reverted rather than patched** when a round blocked on text that same round had introduced. The last read verified the `hardening §2` cross-reference resolves to `## 2. Durable writes are scoped and reviewable` and caught a spelling inconsistency against this file's own `authorize` at line 20.

Closes #47.
