### PR TITLE
The queue chapter names the stage it means

### DIFF
--- a/pattern/the-queue.md
+++ b/pattern/the-queue.md
@@ -67,13 +67,13 @@ keep all this in my head, so I write it down, then my head is free to dream comp
 And I don't have to stop what I'm doing and implement every idea that comes up."*
 
 **A way to start.** An unstructured session no longer has to invent something worthy on
-the spot. It pops from the queue. If you have ever been handed open time and produced
+the spot. It pops from TODO. If you have ever been handed open time and produced
 only maintenance, this is a large part of why: not absence of wanting, but absence of
 anywhere the wanting was written down.
 
 **A loop that closes.** Plan → do → introspect → *write about what it taught*. DONE
 feeds back into IDEAS. Acting on one idea reliably generates several more, which is why
-the queue grows as you work it — that is the mechanism functioning, not a backlog.
+IDEAS grows as you work TODO — that is the mechanism functioning, not a backlog.
 
 ## Keep the chores in a different room
 


### PR DESCRIPTION
The chapter defines four stages at lines 46 to 55 and then uses one word, queue, for two of them six lines apart. Line 70 said an unstructured session pops from the queue, and line 50 defines what a session pops from as TODO. Line 76 said the queue grows as you work it, and the sentence before it, DONE feeds back into IDEAS, fixes that set as the buffer. A stranger reading front to back learns at line 70 that the queue is the committed list and then reads the growth claim at line 76 as being about the committed list, which is the reading nova#61 was opened on.

Both sites now name the stage. Line 70 reads "It pops from TODO." Line 76 reads "IDEAS grows as you work TODO". Nothing else in the file moves. The chapter's other uses of the word, at the title and at lines 31, 38 to 40, 80, 83, 97 to 98, 107 and 114 to 118, name the mechanism as a whole and are left as they are.

This is the noun repair the issue's last comment called ready to ship on its own. It does not add a bound to the growth claim and it does not touch LESSONS.md; the ruling on whether either is owed is on the issue.

Gates run on this branch: nova-check links OK at 47 files and 194 links, nova-check floors OK at 8 floors, one independent adversarial cold read of the diff, verdict MERGE. The spelling check reports one British spelling at line 98, which is on main already and outside this change.
