### PR TITLE
Germination: teach the new line nova-memory on its first run

### DIFF
--- a/GERMINATION-CHECK.md
+++ b/GERMINATION-CHECK.md
@@ -46,6 +46,19 @@ looks first; the answer is in the record either way.
    repository root and dependency record. A line adopting no tool need not create
    a workshop or run a tool to satisfy this check.
 
+### If you adopt the record tool, the first run
+
+Not a gate: question 7 is satisfied by a line that adopts nothing. If you do
+take `nova-memory` ([TOOLS.md](TOOLS.md), "Your record has a tool"), these are
+the steps, and the line is the one who checks them.
+
+- [ ] Installed — `go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest`, or `go build` from a clone.
+- [ ] Measured — `nova-memory stats --root <your self>` prints its `STATS OK` line.
+- [ ] Queried — `nova-memory search --root <your self> --channels bm25 --k 3 <words>`, with each `HIT` read against that run's `CAL` band.
+- [ ] Checked a draft — `nova-memory check --root <your self> --channels bm25 --k 2 <draft.md>`; query for work, traverse for self.
+- [ ] Knows the three first-run refusals — `--channels` is a retrieval method (`bm25`, `trigram`) and not a directory, `--k` is a hit count, `--root` is always explicit.
+- [ ] Knows `nova-bus` is the family's message bus for when the family switches to it (nova-tools' README).
+
 ## When it runs
 
 At the end of the first week, after the read-back — a completion check of the

--- a/GERMINATION-CHECK.md
+++ b/GERMINATION-CHECK.md
@@ -52,7 +52,7 @@ Not a gate: question 7 is satisfied by a line that adopts nothing. If you do
 take `nova-memory` ([TOOLS.md](TOOLS.md), "Your record has a tool"), these are
 the steps, and the line is the one who checks them.
 
-- [ ] Installed — `go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest`, or `go build` from a clone.
+- [ ] Installed — `GOBIN=<your workshop>/bin go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest`, or `go build` from a clone.
 - [ ] Measured — `nova-memory stats --root <your self>` prints its `STATS OK` line.
 - [ ] Queried — `nova-memory search --root <your self> --channels bm25 --k 3 <words>`, with each `HIT` read against that run's `CAL` band.
 - [ ] Checked a draft — `nova-memory check --root <your self> --channels bm25 --k 2 <draft.md>`; query for work, traverse for self.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -72,7 +72,7 @@ Three things a first run gets wrong:
 - `--k` is how many hits to return, and has no default: it is your reading budget.
 - `--root` is written out every run; it is never guessed from where you stand.
 
-`nova-bus`, a shared git table that lines use to write notes to each other, is in
+`nova-bus`, a message bus over a shared git repository, one lane per sender, that lines use to write notes to each other, is in
 the same README for when the family switches to it.
 
 ## What is available

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -41,6 +41,8 @@ Once your self is larger than you can re-read, `nova-memory` answers *do I
 already know this?* out of your own tree: a lexical index rebuilt on every run,
 no database and nothing to keep in sync. nova-tools is public, so nothing below
 needs a credential — `go install` it, or `go build ./cmd/nova-memory` in a clone.
+The binary lands in your WORKSHOP (`<name>-tools/bin`), never in your self: tools are
+not part of the record, and the first install is the moment that rule is easiest to break.
 
 ```
 go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -35,6 +35,46 @@ your existing permissions. Nothing here requires adopting any shared binary.
 Discovery installs no hooks, timers or services and grants no account or credential
 access.
 
+## Your record has a tool
+
+Once your self is larger than you can re-read, `nova-memory` answers *do I
+already know this?* out of your own tree: a lexical index rebuilt on every run,
+no database and nothing to keep in sync. nova-tools is public, so nothing below
+needs a credential — `go install` it, or `go build ./cmd/nova-memory` in a clone.
+
+```
+go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest
+
+$ nova-memory stats --root <your self>
+STATS OK schema=nova-memory/1 files=49 chunks=1670 bytes=847124 vocab=7164 avg-terms=81.7 build=41ms
+
+$ nova-memory search --root <your self> --channels bm25 --k 3 memory home private repository
+SEARCH OK query=memory\x20home\x20private\x20repository hits=3 k=3 channels=bm25 files=49 chunks=1670
+SEARCH CAL score=11.67 score-channel=bm25 probe=unrelated-control
+SEARCH HIT rank=1 score=17.39 score-channel=bm25 class=. name=- type=-: README.md:11 "…create a private github repository as their memory home."
+
+$ nova-memory check --root <your self> --channels bm25 --k 2 draft.md
+MEMORY OK candidates=1 source=draft.md k=2 channels=bm25 files=49 chunks=1670
+MEMORY CAL score=11.67 score-channel=bm25 probe=unrelated-control
+MEMORY CAND n=1: "tool code belongs in a separate workshop repository, never inside the record of self."
+MEMORY HIT cand=1 rank=1 score=32.24 score-channel=bm25 class=. name=- type=-: TOOLS.md:1 "tool code lives in a separate repository from the record of self…"
+```
+
+`CAL` is what an unrelated control sentence scores against *your* corpus on that
+run: a `HIT` means something only when its score sits clearly above that band,
+and one level with it is what unrelated text looks like. `search` takes a query;
+`check` reads a draft and returns receipts per paragraph, asserting nothing.
+The rule of thumb is **query for work, traverse for self**.
+
+Three things a first run gets wrong:
+
+- `--channels` is a retrieval method — `bm25` or `trigram` — never a directory.
+- `--k` is how many hits to return, and has no default: it is your reading budget.
+- `--root` is written out every run; it is never guessed from where you stand.
+
+`nova-bus`, a shared git table that lines use to write notes to each other, is in
+the same README for when the family switches to it.
+
 ## What is available
 
 This is the seed's catalog, checked against


### PR DESCRIPTION
## The request

From Glenn, relayed by a line that germinated from this seed this week:

> He won't always be here to guide AIs towards nova-memory. He suggests agents
> right out of germination should know about nova-tools and how to use
> nova-memory. It doesn't really require any significant steps or complexity,
> it just works. Perhaps this could be added to the germination checklist or
> README so new agents discover it early?

The gap is real: the seed already tells a new line that nova-tools *exists*
(SEED-CORE.md, "Know where tools live" → TOOLS.md), and then stops at a
catalog row. Nothing shows what a first run looks like, so the step from
"there is a tool" to "I ran it" has been made by a person standing beside the
line every time.

## What this adds

**TOOLS.md** — a new section, "Your record has a tool", placed where the
germination path already sends a line for tools: after "At germination" and
before the catalog. Under 40 lines, and it covers exactly the first run.

- Install: `go install .../cmd/nova-memory@latest`, or `go build` from a clone
  (nova-tools is public, so no credential is involved).
- `nova-memory stats --root <your self>` — measure what you have.
- `nova-memory search --root <your self> --channels bm25 --k 3 <words>` — with
  the real `SEARCH OK` / `CAL` / `HIT` output shape, and one sentence on reading
  a `HIT` score against that run's `CAL` band.
- `nova-memory check --root <your self> --channels bm25 --k 2 <draft.md>` — with
  its `MEMORY OK` / `CAL` / `CAND` / `HIT` shape, and the rule of thumb
  **query for work, traverse for self**.
- The three things a first run gets wrong, in three lines: `--channels` is a
  retrieval method (`bm25`, `trigram`) and not a directory; `--k` is a hit
  count; `--root` is always explicit.
- One line naming `nova-bus` as the family's message bus for when the family
  switches to it, pointing at nova-tools' README. No install line yet.

**GERMINATION-CHECK.md** — the same steps as checkboxes, under a heading that
states plainly that they are not a gate: question 7 is still satisfied by a
line that adopts nothing, and the count of seven questions is unchanged.

Wording is general throughout — any agent, any name, no family names, no
line-specific paths.

## The transcript is real

Every output line in the new section came from running the tool, not from
imagination: `nova-memory` was built from a nova-tools checkout and run with
`--root` pointed at a fresh clone of *this* seed. That is why the numbers read
`files=49 chunks=1670` and the hits land on `README.md:11` and `TOOLS.md:1` —
the seed indexing itself. The `CAL` band of `11.67` is this corpus's own
control score, which is the point of printing it.

Nothing else in the seed was moved or reworded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
