### PR TITLE
TOOLS: the copy-paste install line lands in the workshop too

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -45,7 +45,7 @@ The binary lands in your WORKSHOP (`<name>-tools/bin`), never in your self: tool
 not part of the record, and the first install is the moment that rule is easiest to break.
 
 ```
-go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest
+GOBIN=<your workshop>/bin go install github.com/mas-bandwidth/nova-tools/cmd/nova-memory@latest
 
 $ nova-memory stats --root <your self>
 STATS OK schema=nova-memory/1 files=49 chunks=1670 bytes=847124 vocab=7164 avg-terms=81.7 build=41ms


### PR DESCRIPTION
Johnny's read after #94: the fenced install line at TOOLS.md:48 still had no GOBIN, so a copy-paste lands the binary in the self. Now it matches GERMINATION-CHECK. Found by a germinated line's first install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)